### PR TITLE
Couldn't import crnn module using project root as a namespace

### DIFF
--- a/models/model_loader.py
+++ b/models/model_loader.py
@@ -1,7 +1,9 @@
+from collections import OrderedDict
+
 import torch
 from torch import nn
-from models.crnn import CRNN
-from collections import OrderedDict
+
+from .crnn import CRNN
 
 def load_weights(target, source_state):
     new_dict = OrderedDict()


### PR DESCRIPTION
Hi,

I use `crnn-pytorch` as a submodule with name `pytorch_crnn`. The project has no package namespace so I've done a quickfix with a relative import to fix import problem.

The proper way to do this is to introduce single root package (+ setup.py) and move all code except the scripts under this package. Then code can be imported as `from root_package_name.foo import bar`.